### PR TITLE
Updated mvn to include log4j dependency.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,11 @@
       <version>1.2.16</version>
    </dependency>
    <dependency>
+     <groupId>org.slf4j</groupId>
+     <artifactId>slf4j-log4j12</artifactId>
+     <version>1.6.4</version>
+   </dependency>
+   <dependency>
   	<groupId>org.apache.thrift</groupId>
 	  <artifactId>libthrift</artifactId>
 		<version>0.8.0</version>


### PR DESCRIPTION
Without this dependency, the simple logging facade for java (slf4j)
used by thrift fails to find a binding, and uses a useless no-op
logging framework.
