### PR TITLE
Adding two types of benchmarks for the proto backend.

### DIFF
--- a/src/main/java/edu/berkeley/sparrow/daemon/util/TServers.java
+++ b/src/main/java/edu/berkeley/sparrow/daemon/util/TServers.java
@@ -17,6 +17,11 @@ import org.apache.thrift.transport.TTransportException;
 public class TServers {
   private final static Logger LOG = Logger.getLogger(TServers.class);
 
+  /**
+   * Launch a multi-threaded Thrift server with the given {@code processor}. Note that 
+   * internally this creates an expanding thread pool of at most {@code threads} threads,
+   * and requests are queued whenever that thread pool is saturated.
+   */
   public static void launchThreadedThriftServer(int port, int threads,
       TProcessor processor) throws IOException {
     LOG.info("Staring async thrift server of type: " + processor.getClass().toString());

--- a/src/main/java/edu/berkeley/sparrow/prototype/ProtoFrontend.java
+++ b/src/main/java/edu/berkeley/sparrow/prototype/ProtoFrontend.java
@@ -60,14 +60,14 @@ public class ProtoFrontend {
     }
   }
   
-  public static List<TTaskSpec> generateJob(int numTasks, int banchmarkId, 
-      int banchmarkIterations) {
+  public static List<TTaskSpec> generateJob(int numTasks, int benchmarkId, 
+      int benchmarkIterations) {
     TResourceVector resources = TResources.createResourceVector(300, 1);
     
     // Pack task parameters
     ByteBuffer message = ByteBuffer.allocate(8);
-    message.putInt(banchmarkId);
-    message.putInt(banchmarkIterations);
+    message.putInt(benchmarkId);
+    message.putInt(benchmarkIterations);
     
     List<TTaskSpec> out = new ArrayList<TTaskSpec>();
     for (int taskId = 0; taskId < numTasks; taskId++) {


### PR DESCRIPTION
One is a CPU intensive and one is memory + CPU intensive. Also, adding some
better documentation about the thread pool behavior in the thrift servers.
