### PR TITLE
A variety of performance and debugging oriented changes.

### DIFF
--- a/src/main/java/edu/berkeley/sparrow/daemon/nodemonitor/NodeMonitor.java
+++ b/src/main/java/edu/berkeley/sparrow/daemon/nodemonitor/NodeMonitor.java
@@ -43,7 +43,7 @@ public class NodeMonitor {
       new HashMap<String, Map<TUserGroupInfo, TResourceVector>>();
   
   /** Cache of thrift clients pools for each backends. It is expected that clients
-   *  are removed from the pool when in use.*/
+   *  are removed from the pool when in use. */
   private HashMap<String, BlockingQueue<BackendService.Client>> backendClients =
       new HashMap<String, BlockingQueue<BackendService.Client>>();
   private TResourceVector capacity;
@@ -191,7 +191,7 @@ public class NodeMonitor {
     try {
       client = backendClients.get(app).take();
     } catch (InterruptedException e) {
-      LOG.error(e);
+      LOG.fatal(e);
     }
     
     client.launchTask(message, requestId, taskId, user, estimatedResources);
@@ -199,7 +199,7 @@ public class NodeMonitor {
     try {
       backendClients.get(app).put(client);
     } catch (InterruptedException e) {
-      LOG.error(e);
+      LOG.fatal(e);
     }
     LOG.debug("Launched task " + taskId + " for app " + app);
     return true;

--- a/src/main/java/edu/berkeley/sparrow/daemon/nodemonitor/NodeMonitorThrift.java
+++ b/src/main/java/edu/berkeley/sparrow/daemon/nodemonitor/NodeMonitorThrift.java
@@ -30,7 +30,7 @@ public class NodeMonitorThrift implements NodeMonitorService.Iface,
   public final static int DEFAULT_NM_THRIFT_PORT = 20501;
   public final static int DEFAULT_NM_THRIFT_THREADS = 2;
   public final static int DEFAULT_INTERNAL_THRIFT_PORT = 20502;
-  public final static int DEFAULT_INTERNAL_THRIFT_THREADS = 2;
+  public final static int DEFAULT_INTERNAL_THRIFT_THREADS = 8;
  
   private NodeMonitor nodeMonitor = new NodeMonitor();
   // The socket addr (ip:port) where we listen for requests from other Sparrow daemons.

--- a/src/main/java/edu/berkeley/sparrow/daemon/scheduler/Scheduler.java
+++ b/src/main/java/edu/berkeley/sparrow/daemon/scheduler/Scheduler.java
@@ -99,6 +99,7 @@ public class Scheduler {
 
   public boolean submitJob(TSchedulingRequest req) throws TException {
     LOG.debug(Logging.functionCall(req));
+    long start = System.currentTimeMillis();
     
     String requestId = getRequestId();
     // Logging the address here is somewhat redundant, since all of the
@@ -116,6 +117,7 @@ public class Scheduler {
       e.printStackTrace();
       return false;
     }
+    long probeFinish = System.currentTimeMillis();
     
     // Launch tasks.
     CountDownLatch latch = new CountDownLatch(placement.size());
@@ -137,7 +139,9 @@ public class Scheduler {
     } catch (InterruptedException e) {
       e.printStackTrace();
     }
-    LOG.debug("All tasks launched, returning");
+    long end = System.currentTimeMillis();
+    LOG.debug("All tasks launched, returning. Total time: " + (end - start) + 
+        "Probe time: " + (probeFinish - start));
     return true;
   }
 

--- a/src/main/java/edu/berkeley/sparrow/daemon/scheduler/SchedulerThrift.java
+++ b/src/main/java/edu/berkeley/sparrow/daemon/scheduler/SchedulerThrift.java
@@ -20,7 +20,7 @@ import edu.berkeley.sparrow.thrift.TTaskPlacement;
 public class SchedulerThrift implements SchedulerService.Iface {
   // Defaults if not specified by configuration
   public final static int DEFAULT_SCHEDULER_THRIFT_PORT = 20503;
-  private final static int DEFAULT_SCHEDULER_THRIFT_THREADS = 2;
+  private final static int DEFAULT_SCHEDULER_THRIFT_THREADS = 8;
   
   private Scheduler scheduler = new Scheduler();
 

--- a/src/main/java/edu/berkeley/sparrow/prototype/ProtoFrontend.java
+++ b/src/main/java/edu/berkeley/sparrow/prototype/ProtoFrontend.java
@@ -57,7 +57,7 @@ public class ProtoFrontend {
       try {
         client.initialize(new InetSocketAddress("localhost", schedulerPort), "testApp");
       } catch (TException e) {
-        LOG.error(e);
+        LOG.fatal(e);
       }
       TUserGroupInfo user = new TUserGroupInfo();
       user.setUser("*");
@@ -151,7 +151,6 @@ public class ProtoFrontend {
        * compounding time lost during sleep()'s;
        */
       while (true) {
-        System.out.println("Threads: " + Thread.activeCount());
         // Lambda is the arrival rate in S, so we need to multiply the result here by
         // 1000 to convert to ms.
         long delay = (long) (generateInterarrivalDelay(r, lambda) * 1000);

--- a/src/main/java/edu/berkeley/sparrow/prototype/ProtoFrontend.java
+++ b/src/main/java/edu/berkeley/sparrow/prototype/ProtoFrontend.java
@@ -5,6 +5,7 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import joptsimple.OptionParser;
 import joptsimple.OptionSet;
@@ -35,28 +36,41 @@ public class ProtoFrontend {
   public static final int DEFAULT_BENCHMARK_ITERATIONS = 10;  // # of benchmark iterations
   
   private static final Logger LOG = Logger.getLogger(ProtoFrontend.class);
+  public final static long startTime = System.currentTimeMillis();
+  public static AtomicInteger tasksLaunched = new AtomicInteger(0);
 
   /** A runnable which Spawns a new thread to launch a scheduling request. */
   private static class JobLaunchRunnable implements Runnable {
     private List<TTaskSpec> request;
+    private int schedulerPort;
     private SparrowFrontendClient client;
     
-    public JobLaunchRunnable(List<TTaskSpec> request, SparrowFrontendClient client) {
+    public JobLaunchRunnable(List<TTaskSpec> request, int schedulerPort) {
       this.request = request;
-      this.client = client;
+      this.schedulerPort = schedulerPort;
     }
     
     @Override
     public void run() {
+      long start = System.currentTimeMillis();
+      client = new SparrowFrontendClient();
+      try {
+        client.initialize(new InetSocketAddress("localhost", schedulerPort), "testApp");
+      } catch (TException e) {
+        LOG.error(e);
+      }
       TUserGroupInfo user = new TUserGroupInfo();
       user.setUser("*");
       user.setGroup("*");
       try {
         client.submitJob("testApp", request, user);
-        LOG.debug("Submitted job");
+        LOG.debug("Submitted job: " + request);
       } catch (TException e) {
         LOG.error("Scheduling request failed!", e);
       }
+      client.close();
+      long end = System.currentTimeMillis();
+      LOG.debug("Scheduling request duration " + (end - start));
     }
   }
   
@@ -72,7 +86,7 @@ public class ProtoFrontend {
     List<TTaskSpec> out = new ArrayList<TTaskSpec>();
     for (int taskId = 0; taskId < numTasks; taskId++) {
       TTaskSpec spec = new TTaskSpec();
-      spec.setTaskID(Integer.toString(taskId));
+      spec.setTaskID(Integer.toString((new Random().nextInt())));
       spec.setMessage(message.array());
       spec.setEstimatedResources(resources);
       out.add(spec);
@@ -120,15 +134,41 @@ public class ProtoFrontend {
       int schedulerPort = conf.getInt("scheduler_port", 
           SchedulerThrift.DEFAULT_SCHEDULER_THRIFT_PORT);
       client.initialize(new InetSocketAddress("localhost", schedulerPort), "testApp");
+      long lastLaunch = System.currentTimeMillis();
       
-      // Loop and generate tasks launches
+      /* This is a little tricky. 
+       * 
+       * We want to generate inter-arrival delays according to the arrival rate specified.
+       * The simplest option would be to generate an arrival delay and then sleep() for it
+       * before launching each task. This has in issue, however: sleep() might wait 
+       * several ms longer than we ask it to. When task arrival rates get really fast, 
+       * i.e. one task every 10 ms, sleeping an additional few ms will mean we launch 
+       * tasks at a much lower rate than requested.
+       * 
+       * Instead, we keep track of task launches in a way that does not depend on how long
+       * sleep() actually takes. We still might have tasks launch slightly after their
+       * scheduled launch time, but we will not systematically "fall behind" due to
+       * compounding time lost during sleep()'s;
+       */
       while (true) {
+        System.out.println("Threads: " + Thread.activeCount());
         // Lambda is the arrival rate in S, so we need to multiply the result here by
         // 1000 to convert to ms.
-        Thread.sleep((long) (generateInterarrivalDelay(r, lambda) * 1000));
+        long delay = (long) (generateInterarrivalDelay(r, lambda) * 1000);
+        long curLaunch = lastLaunch + delay;
+        long toWait = Math.max(0,  curLaunch - System.currentTimeMillis());       
+        lastLaunch = curLaunch;
+        if (toWait == 0) {
+          LOG.warn("Lanching task after start time in generated workload.");
+        }
+        Thread.sleep(toWait);
         Runnable runnable =  new JobLaunchRunnable(
-            generateJob(tasksPerJob, benchmarkId, benchmarkIterations), client);
+            generateJob(tasksPerJob, benchmarkId, benchmarkIterations), schedulerPort);
         new Thread(runnable).start();
+        int launched = tasksLaunched.addAndGet(1);
+        double launchRate = (double) launched * 1000.0 / 
+            (System.currentTimeMillis() - startTime);
+        LOG.debug("Aggregate launch rate: " + launchRate);
       }
     }
     catch (Exception e) {


### PR DESCRIPTION
- NodeMonitor now uses a pool of clients for each backend, so task launches
  don't get serialized behind communication of a single client.
- Default thread counts are increased in several classes.
- Profiling statistics and reporting are added to several classes.
- ProtoFrontend creates a new client for each request, so it does not share
  a single client amongst all task launches.
- ProtoFrontend uses the more sophisticated traffic generation that takes
  into account lost sleep() time.
