### PR TITLE
Node Monitor Queueing

### DIFF
--- a/src/main/java/edu/berkeley/sparrow/daemon/nodemonitor/NoQueueTaskScheduler.java
+++ b/src/main/java/edu/berkeley/sparrow/daemon/nodemonitor/NoQueueTaskScheduler.java
@@ -1,0 +1,31 @@
+package edu.berkeley.sparrow.daemon.nodemonitor;
+
+import org.apache.log4j.Logger;
+
+
+/**
+ * A {@link TaskScheduler} which makes tasks instantly available for launch.
+ * 
+ * This does not perform any resource management or queuing. It can be used for 
+ * applications which do not want Sparrow to perform any explicit resource management 
+ * but still want Sparrow to launch tasks.
+ */
+public class NoQueueTaskScheduler extends TaskScheduler {
+  private final static Logger LOG = Logger.getLogger(NoQueueTaskScheduler.class);
+
+  @Override
+  void handleSubmitTask(TaskDescription task) {
+    // Make this task instantly runnable
+    try {
+      runnableTaskQueue.put(task);
+    } catch (InterruptedException e) {
+      LOG.fatal(e);
+    }
+  }
+
+  @Override
+  protected void handleTaskCompleted(String taskId) {
+    // Do nothing
+  }
+
+}

--- a/src/main/java/edu/berkeley/sparrow/daemon/nodemonitor/NodeMonitor.java
+++ b/src/main/java/edu/berkeley/sparrow/daemon/nodemonitor/NodeMonitor.java
@@ -33,6 +33,8 @@ public class NodeMonitor {
   private final static Logger LOG = Logger.getLogger(NodeMonitor.class);
   private final static Logger AUDIT_LOG = Logging.getAuditLogger(NodeMonitor.class);
   private final static int DEFAULT_MEMORY_MB = 1024; // Default memory capacity
+  private final static int DEFAULT_CORES = 8;        // Default CPU capacity
+  
   /** How many blocking thrift clients to make for each registered backend. */ 
   
   private static NodeMonitorState state;
@@ -93,7 +95,8 @@ public class NodeMonitor {
       LOG.info("Using default memory allocation: " + DEFAULT_MEMORY_MB);
       capacity.setMemory(DEFAULT_MEMORY_MB);  
     }
-    capacity.setCores(8);
+    LOG.info("Using default core count: " + DEFAULT_CORES);
+    capacity.setCores(DEFAULT_CORES);
     
     scheduler = new RoundRobinTaskScheduler();
     scheduler.initialize(capacity);
@@ -187,7 +190,7 @@ public class NodeMonitor {
   public boolean launchTask(String app, ByteBuffer message, String requestId,
       String taskId, TUserGroupInfo user, TResourceVector estimatedResources)
           throws TException {
-    /* Task id's need not be unique between scheduling requests, so here we use an
+    /* Task ids need not be unique between scheduling requests, so here we use an
      * identifier which contains the request id, so we can tell when this task has
      * finished. */
     String compoundId = taskId + "-" + requestId;

--- a/src/main/java/edu/berkeley/sparrow/daemon/nodemonitor/RoundRobinTaskScheduler.java
+++ b/src/main/java/edu/berkeley/sparrow/daemon/nodemonitor/RoundRobinTaskScheduler.java
@@ -1,0 +1,89 @@
+package edu.berkeley.sparrow.daemon.nodemonitor;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.Queue;
+
+import org.apache.log4j.Logger;
+
+import edu.berkeley.sparrow.daemon.util.TResources;
+
+/**
+ * A {@link TaskScheduler} which round-robin's requests over backlogged per-user queues.
+ */
+public class RoundRobinTaskScheduler extends TaskScheduler {
+  private final static Logger LOG = Logger.getLogger(RoundRobinTaskScheduler.class);
+
+  private HashMap<String, Queue<TaskDescription>> userQueues = 
+      new HashMap<String, Queue<TaskDescription>>();
+
+  private ArrayList<String> users = new ArrayList<String>();
+  private int currIndex = 0;
+
+  @Override
+  void handleSubmitTask(TaskDescription task) {
+    if (TResources.isLessThanOrEqualTo(task.estimatedResources, getUnAssignedResources())) {
+      try {
+        runnableTaskQueue.put(task);
+      } catch (InterruptedException e) {
+      }
+    } else {
+      addTaskToUserQueue(task.user.user, task);
+    }
+  }
+  
+  void addTaskToUserQueue(String user, TaskDescription task) {
+    synchronized(userQueues) {
+      if (!userQueues.containsKey(user)) {
+        userQueues.put(user, new LinkedList<TaskDescription>());
+        users.add(user);
+      }
+      userQueues.get(user).add(task);
+    }
+  }
+  
+  void removeTaskFromUserQueue(String user, TaskDescription task) {
+    synchronized(userQueues) {
+      userQueues.get(user).remove(task);
+      if (userQueues.get(user).size() == 0) {
+        userQueues.remove(user);
+        users.remove(user);
+      }
+    }
+  }
+
+  @Override
+  protected void handleTaskCompleted(String taskId) {
+    synchronized(userQueues) {
+      /* Scan through the list of users (starting at currentIndex) and find the first
+       * one with a pending tasks. If we find a pending task, make that task runnable
+       * and update the round robin index.
+       * 
+       * Note that this implementation assumes that we can take an arbitrary task and,
+       * by virtue of a task having just finished, have enough resources to execute it. 
+       * This makes sense for scheduling similar sized tasks (e.g. just scheduling cores)
+       * but will not be the case if tasks take different amounts of resources. */
+      for (int i = 0; i < users.size(); i++) {
+        String user = users.get((currIndex + i) % users.size());
+        Queue<TaskDescription> considering = userQueues.get(user);
+        TaskDescription nextTask = considering.poll();
+        if (nextTask == null) {
+          continue;
+        }
+        else {
+          try {
+            runnableTaskQueue.put(nextTask);
+            removeTaskFromUserQueue(user, nextTask);
+            currIndex = currIndex + i + 1;
+            return;
+          } catch (InterruptedException e) {
+            LOG.fatal(e);
+          }
+        }
+      }
+      // No one had a task, so do nothing.
+    }
+  }
+
+}

--- a/src/main/java/edu/berkeley/sparrow/daemon/nodemonitor/TaskLauncherService.java
+++ b/src/main/java/edu/berkeley/sparrow/daemon/nodemonitor/TaskLauncherService.java
@@ -1,0 +1,109 @@
+package edu.berkeley.sparrow.daemon.nodemonitor;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.util.HashMap;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingDeque;
+
+import org.apache.commons.configuration.Configuration;
+import org.apache.log4j.Logger;
+import org.apache.thrift.TException;
+
+import edu.berkeley.sparrow.daemon.nodemonitor.TaskScheduler.TaskDescription;
+import edu.berkeley.sparrow.daemon.util.Logging;
+import edu.berkeley.sparrow.daemon.util.TClients;
+import edu.berkeley.sparrow.thrift.BackendService;
+
+/**
+ * Creates a thread pool which is responsible for launching tasks on backends.
+ * 
+ * This class pulls runnable tasks from a {@link TaskScheduler} and executes them. 
+ */
+public class TaskLauncherService {
+  private final static Logger LOG = Logger.getLogger(TaskLauncherService.class);
+  private final static Logger AUDIT_LOG = Logging.getAuditLogger(
+      TaskLauncherService.class);
+  public final static int CLIENT_POOL_SIZE = 10;
+  
+  /** A runnable which spins in a loop asking for tasks to launch and launching them. */
+  private class TaskLaunchRunnable implements Runnable {
+    @Override
+    public void run() {
+      while (true) {
+        TaskDescription task = scheduler.getNextTask(); // blocks until task is ready
+        BackendService.Client client = null;
+        if (!backendClients.containsKey(task.backendSocket)) {
+          createThriftClients(task.backendSocket);
+        }
+        try {
+          client = backendClients.get(task.backendSocket).take();
+        } catch (InterruptedException e) {
+          LOG.fatal(e);
+        }
+        AUDIT_LOG.info(Logging.auditEventString("nodemonitor_launch_call_start", 
+            task.requestId, address.getHostAddress(), task.taskId));
+        
+        try {
+          client.launchTask(task.message, task.requestId, task.taskId, task.user, 
+              task.estimatedResources);
+        } catch (TException e) {
+          LOG.error("Error launching task: " + task.taskId, e);
+        }
+        
+        AUDIT_LOG.info(Logging.auditEventString("nodemonitor_launch_call_finish", 
+            task.requestId, address.getHostAddress(), task.taskId));
+        
+        try {
+          backendClients.get(task.backendSocket).put(client);
+        } catch (InterruptedException e) {
+          LOG.fatal(e);
+        }
+        
+        AUDIT_LOG.info(Logging.auditEventString("nodemonitor_launch_finish", 
+            task.requestId, address.getHostAddress(), task.taskId));
+        LOG.debug("Launched task " + task.taskId);
+      }
+    }
+  }
+  
+  private TaskScheduler scheduler;
+  private InetAddress address;
+
+  /** Cache of thrift clients pools for each backends. Clients are removed from the pool
+   *  when in use. */
+  private HashMap<InetSocketAddress, BlockingQueue<BackendService.Client>> backendClients =
+      new HashMap<InetSocketAddress, BlockingQueue<BackendService.Client>>();
+  
+  public void initialize(Configuration conf, TaskScheduler scheduler, 
+      InetAddress address) {
+    this.scheduler = scheduler;
+    this.address = address;
+    ExecutorService service = Executors.newFixedThreadPool(CLIENT_POOL_SIZE);
+    for (int i = 0; i < CLIENT_POOL_SIZE; i++) {
+      service.submit(new TaskLaunchRunnable());
+    }
+  }
+  
+  /** Creates a set of thrift clients and adds them to the client pool. */
+  public void createThriftClients(InetSocketAddress backendAddr) {
+    BlockingQueue<BackendService.Client> clients = new 
+        LinkedBlockingDeque<BackendService.Client>();
+    for (int i = 0; i < CLIENT_POOL_SIZE; i++) {
+      try {
+        clients.put(TClients.createBlockingBackendClient(
+            backendAddr.getHostName(), backendAddr.getPort()));
+      } catch (InterruptedException e) {
+        LOG.error("Interrupted creating thrift clients", e);
+      } catch (IOException e) {
+        LOG.error("Error creating thrift client", e);
+      }
+    }
+    backendClients.put(backendAddr, clients);
+  }
+  
+  
+}

--- a/src/main/java/edu/berkeley/sparrow/daemon/nodemonitor/TaskScheduler.java
+++ b/src/main/java/edu/berkeley/sparrow/daemon/nodemonitor/TaskScheduler.java
@@ -1,0 +1,116 @@
+package edu.berkeley.sparrow.daemon.nodemonitor;
+
+import java.net.InetSocketAddress;
+import java.nio.ByteBuffer;
+import java.util.HashMap;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+
+import org.apache.log4j.Logger;
+
+import edu.berkeley.sparrow.daemon.util.TResources;
+import edu.berkeley.sparrow.thrift.TResourceVector;
+import edu.berkeley.sparrow.thrift.TUserGroupInfo;
+
+/**
+ * A TaskScheduler is a buffer that holds tasks between when they are launched on a
+ * {@link NodeMonitor} and when they are passed to application backends.
+ * 
+ * Each scheduler will implement a different policy determining when to launch tasks.
+ * 
+ * Schedulers are required to be thread safe, as they will be accessed concurrently from
+ * multiple threads.
+ */
+public abstract class TaskScheduler {
+  private final static Logger LOG = Logger.getLogger(TaskScheduler.class);
+  
+  class TaskDescription {
+    ByteBuffer message;
+    public String requestId;
+    public String taskId;
+    public TResourceVector estimatedResources;
+    public TUserGroupInfo user;
+    public InetSocketAddress backendSocket;
+    
+    public TaskDescription(String taskId, String requestId, ByteBuffer message, 
+        TResourceVector estimatedResources, TUserGroupInfo user, InetSocketAddress addr) {
+      this.taskId = taskId;
+      this.requestId = requestId;
+      this.message = message;
+      this.estimatedResources = estimatedResources;
+      this.user = user;
+      this.backendSocket = addr;
+    }
+  }
+  
+  protected TResourceVector capacity;
+  protected TResourceVector inUse = TResources.none();
+  protected final BlockingQueue<TaskDescription> runnableTaskQueue = 
+      new LinkedBlockingQueue<TaskDescription>();
+  protected final static TResourceVector ONE_CORE = TResources.createResourceVector(0, 1);
+  private HashMap<String, TResourceVector> resourcesPerTask = new 
+      HashMap<String, TResourceVector>();
+  
+  /** Initialize the task scheduler, passing it the current available resources 
+   *  on the machine. */
+  void initialize(TResourceVector capacity) {
+    this.capacity = capacity;
+  }
+  
+  /**
+   * Get the next task available for launching. This will block until a task is available.
+   */
+  TaskDescription getNextTask() {
+    TaskDescription task = null;
+    try {
+      task = runnableTaskQueue.take();
+    } catch (InterruptedException e) {
+      LOG.fatal(e);
+    }
+    addResourceInUse(task.estimatedResources);
+    return task;
+  }  
+  
+  /**
+   * Returns the current number of runnable tasks (for testing).
+   */
+  int runnableTasks() {
+    return runnableTaskQueue.size();
+  }
+
+  void taskCompleted(String taskId) {
+    freeResourceInUse(ONE_CORE);
+    handleTaskCompleted(taskId);
+  }
+  
+  void submitTask(TaskDescription task) {
+    resourcesPerTask.put(task.taskId, task.estimatedResources);
+    handleSubmitTask(task);
+  }
+  
+  protected synchronized void addResourceInUse(TResourceVector nowInUse) {
+    inUse = TResources.add(inUse, nowInUse);
+  }  
+  protected synchronized void freeResourceInUse(TResourceVector nowFreed) {
+    TResources.subtractFrom(inUse, nowFreed);
+  }
+  protected synchronized TResourceVector getUnAssignedResources() {
+    TResourceVector free = TResources.subtract(capacity, inUse);
+    TResourceVector reserved = TResources.none();
+    for (TaskDescription t: runnableTaskQueue) {
+      reserved = TResources.add(reserved, t.estimatedResources);
+    }
+    return TResources.subtract(free, reserved);
+  }
+  
+  /**
+   * Submit a task to the scheduler.
+   */
+  abstract void handleSubmitTask(TaskDescription task);
+  
+  /**
+   * Signal that a given task has completed.
+   */
+  protected abstract void handleTaskCompleted(String taskId);
+  
+}

--- a/src/main/java/edu/berkeley/sparrow/daemon/util/TResources.java
+++ b/src/main/java/edu/berkeley/sparrow/daemon/util/TResources.java
@@ -46,13 +46,25 @@ public class TResources {
     return addTo(clone(a), b);
   }
   
+  /** Subtract resource {@code b} from resource {@code a} and return the result */
+  public static TResourceVector subtract(TResourceVector a, TResourceVector b) {
+    return (subtractFrom(clone(a), b));
+  }
+  
   /** Return whether this resource is valid. */
   public static boolean isValid(TResourceVector r) {
-    return (r.memory > 0 && r.cores > 0);
+    return (r.memory >= 0 && r.cores >= 0);
   }
   
   /** Return whether two resources are equal. */
   public static boolean equal(TResourceVector a, TResourceVector b) {
     return ((a.getMemory() == b.getMemory()) && (a.getCores() == b.getCores()));
+  }
+  
+  /** Return whether resource {@code a} is less than or equal resource {@code b}, 
+   *  meaning all pairwise comparisons fulfill {@code a <= b}. 
+   */
+  public static boolean isLessThanOrEqualTo(TResourceVector a, TResourceVector b) {
+    return (a.getMemory() <= b.getMemory()) && (a.getCores() <= b.getCores());
   }
 }

--- a/src/test/java/edu/berkeley/sparrow/daemon/nodemonitor/TestRoundRobinScheduler.java
+++ b/src/test/java/edu/berkeley/sparrow/daemon/nodemonitor/TestRoundRobinScheduler.java
@@ -1,0 +1,136 @@
+package edu.berkeley.sparrow.daemon.nodemonitor;
+import static org.junit.Assert.*;
+
+import java.net.InetSocketAddress;
+import java.nio.ByteBuffer;
+
+import org.junit.Test;
+
+import edu.berkeley.sparrow.daemon.nodemonitor.TaskScheduler.TaskDescription;
+import edu.berkeley.sparrow.daemon.util.TResources;
+import edu.berkeley.sparrow.thrift.TResourceVector;
+import edu.berkeley.sparrow.thrift.TUserGroupInfo;
+
+public class TestRoundRobinScheduler {
+  private TaskDescription createTaskDescription(int id, TUserGroupInfo user, 
+      TaskScheduler scheduler) {
+    String idStr = Integer.toString(id);
+    return scheduler.new TaskDescription(
+            idStr, idStr, ByteBuffer.wrap(new byte[] {(byte) id}), 
+            TResources.createResourceVector(0, 1), 
+            user, InetSocketAddress.createUnresolved("localhost", 1234));
+  }
+  
+  @Test
+  public void testBasicRoundRobin() {
+    TaskScheduler scheduler = new RoundRobinTaskScheduler();
+    TResourceVector capacity = TResources.createResourceVector(0, 4);
+    scheduler.initialize(capacity);
+    
+    TUserGroupInfo user1 = new TUserGroupInfo();
+    user1.user = "user1";
+    user1.group = "user1";
+    
+    TUserGroupInfo user2 = new TUserGroupInfo();
+    user2.user = "user2";
+    user2.group = "user2";
+    
+    TUserGroupInfo user3 = new TUserGroupInfo();
+    user3.user = "user3";
+    user3.group = "user3";
+        
+    // Submit enough tasks to saturate the existing capacity.
+    scheduler.handleSubmitTask(createTaskDescription(1, user1, scheduler));
+    assertEquals(1, scheduler.runnableTasks());
+    scheduler.getNextTask();
+    assertEquals(0, scheduler.runnableTasks());
+
+    scheduler.handleSubmitTask(createTaskDescription(2, user2, scheduler));
+    assertEquals(1, scheduler.runnableTasks());
+    scheduler.getNextTask();
+    assertEquals(0, scheduler.runnableTasks());
+    
+    scheduler.handleSubmitTask(createTaskDescription(3, user3, scheduler));
+    assertEquals(1, scheduler.runnableTasks());
+    scheduler.getNextTask();
+    assertEquals(0, scheduler.runnableTasks());
+    
+    scheduler.handleSubmitTask(createTaskDescription(4, user1, scheduler));
+    assertEquals(1, scheduler.runnableTasks());
+    scheduler.getNextTask();
+    assertEquals(0, scheduler.runnableTasks());
+    
+    /* Create the following backlogs.
+     * user1: 2 tasks
+     * user2: 3 tasks
+     * user3: 4 tasks
+     */
+    scheduler.handleSubmitTask(createTaskDescription(5, user1, scheduler));
+    scheduler.handleSubmitTask(createTaskDescription(6, user1, scheduler));
+    scheduler.handleSubmitTask(createTaskDescription(7, user2, scheduler));
+    scheduler.handleSubmitTask(createTaskDescription(8, user2, scheduler));
+    scheduler.handleSubmitTask(createTaskDescription(9, user2, scheduler));
+    scheduler.handleSubmitTask(createTaskDescription(10, user3, scheduler));
+    scheduler.handleSubmitTask(createTaskDescription(11, user3, scheduler));
+    scheduler.handleSubmitTask(createTaskDescription(12, user3, scheduler));
+    scheduler.handleSubmitTask(createTaskDescription(13, user3, scheduler));
+
+    assertEquals(0, scheduler.runnableTasks());
+    
+    // Make sure that as tasks finish (and space is freed up) new tasks are added to the
+    // runqueue in round-robin order.
+    scheduler.taskCompleted("1");
+    assertEquals(1, scheduler.runnableTasks());
+    TaskDescription task = scheduler.getNextTask();
+    assertEquals("user1", task.user.user);
+    assertEquals(0, scheduler.runnableTasks()); 
+    
+    scheduler.taskCompleted(task.taskId);
+    assertEquals(1, scheduler.runnableTasks()); 
+    task = scheduler.getNextTask();
+    assertEquals("user2", task.user.user);
+    assertEquals(0, scheduler.runnableTasks());
+    
+    scheduler.taskCompleted(task.taskId);
+    assertEquals(1, scheduler.runnableTasks()); 
+    task = scheduler.getNextTask();
+    assertEquals("user3", task.user.user);
+    assertEquals(0, scheduler.runnableTasks());
+    
+    scheduler.taskCompleted(task.taskId);
+    assertEquals(1, scheduler.runnableTasks());
+    task = scheduler.getNextTask();
+    assertEquals("user1", task.user.user);
+    assertEquals(0, scheduler.runnableTasks()); 
+    
+    scheduler.taskCompleted(task.taskId);
+    assertEquals(1, scheduler.runnableTasks()); 
+    task = scheduler.getNextTask();
+    assertEquals("user2", task.user.user);
+    assertEquals(0, scheduler.runnableTasks());
+    
+    scheduler.taskCompleted(task.taskId);
+    assertEquals(1, scheduler.runnableTasks()); 
+    task = scheduler.getNextTask();
+    assertEquals("user3", task.user.user);
+    assertEquals(0, scheduler.runnableTasks());
+    
+    scheduler.taskCompleted(task.taskId);
+    assertEquals(1, scheduler.runnableTasks()); 
+    task = scheduler.getNextTask();
+    assertEquals("user2", task.user.user);
+    assertEquals(0, scheduler.runnableTasks());
+    
+    scheduler.taskCompleted(task.taskId);
+    assertEquals(1, scheduler.runnableTasks()); 
+    task = scheduler.getNextTask();
+    assertEquals("user3", task.user.user);
+    assertEquals(0, scheduler.runnableTasks());
+    
+    scheduler.taskCompleted(task.taskId);
+    assertEquals(1, scheduler.runnableTasks()); 
+    task = scheduler.getNextTask();
+    assertEquals("user3", task.user.user);
+    assertEquals(0, scheduler.runnableTasks());
+  }
+}


### PR DESCRIPTION
These two commits allow the node monitor to perform queuing of tasks when resources become temporarily oversubscribed. See the first commit message for a longer discussion of the architectural changes.
