### PR TITLE
Added debugging to understand repsonse times for large simulations.

### DIFF
--- a/simulation/graph.py
+++ b/simulation/graph.py
@@ -230,9 +230,63 @@ def fairness(load_metric, num_users):
                            (file_prefix, user_id, user_id + 1))
     gnuplot_file.close()
     return gnuplot_filename
+
+def debug_load_vs_wait(file_prefix, utilization, num_servers, tasks_per_job,
+                       probes_ratio):
+    """ This debugs anomalous performance by plotting wait time.
+    
+    The output files plot a CDF of wait time for each load (as returned by
+    the probe to the server).
+    """
+    task_length = 100
+    arrival_delay = (task_length * tasks_per_job /
+                     (num_servers * utilization))
+    network_delay = 1
+    total_time = 1e4
+    simulation.main(["job_arrival_delay=%f" % arrival_delay,
+                     "num_users=1",
+                     "network_delay=%d" % network_delay,
+                     "probes_ratio=%f" % probes_ratio,
+                     "task_length_distribution=constant",
+                     "num_tasks=%d" % tasks_per_job,
+                     "task_length=%d" % task_length,
+                     "task_distribution=constant",
+                     "load_metric=total",
+                     "file_prefix=%s" % file_prefix,
+                     "num_servers=%d" % num_servers,
+                     "total_time=%d" % total_time,
+                     "first_time=True",
+                     "record_task_info=True"])
+    for job_or_task in ["job", "task"]:
+        output_prefix = "%s_%s" % (file_prefix, job_or_task)
+        data_filename = "raw_results/%s_wait_cdf" % output_prefix
+        # Figure out how many load lines to plot.
+        data_file = open(data_filename, "r")
+        items = data_file.readline().split("\t")
+        num_load_values = len(items) - 2
+        data_file.close()
+    
+        filename = "plot_%s.gp" % output_prefix
+        gnuplot_file = open(filename, 'w')
+        gnuplot_file.write("set terminal postscript color 'Helvetica' 14\n")
+        gnuplot_file.write("set size 0.5,0.5\n")
+        gnuplot_file.write("set output 'graphs/%s.ps'\n" % output_prefix)
+        gnuplot_file.write("set xlabel 'Task Wait Time (ms)'\n")
+        gnuplot_file.write("set ylabel 'Cumulative Probability'\n")
+        gnuplot_file.write("set grid ytics\n")
+        gnuplot_file.write("plot ")
+        for load in range(num_load_values):
+            if load != 0:
+                gnuplot_file.write(", \\\n")
+            gnuplot_file.write("'%s' using %d:1 with l lw 4 title 'Load=%d'"
+                               % (data_filename, load+2, load))
+        gnuplot_file.close()
+        
+        subprocess.call(["gnuplot", filename])
+    
         
 ###############################################################################
-#               Graphs for Final Paper/Poster for Ion's Class                 #
+#               More sophisticated graphing functionality.                    #
 ###############################################################################
 
 class EffectOfNetworkDelay:
@@ -544,8 +598,7 @@ class EffectOfProbes:
         
 def main():
     # Fill this in with whatever experiment should be run.
-    network_delay = EffectOfProbes("small_lowdelay")
-    network_delay.run(1)
+    debug_load_vs_wait("step_high", 0.8, 10000, 200, 1.5)
 
 if __name__ == '__main__':
     main()

--- a/simulation/simulation.py
+++ b/simulation/simulation.py
@@ -92,8 +92,6 @@ PARAMS = {'num_fes': [int, 1],             # number of frontends
           # packs multiple tasks on each node to minimize the overall queue
           # length.
           'queue_selection': [str, 'greedy'],
-          # Whether extra queue state should be recorded.
-          'record_queue_state': [lambda x: x == "True", False],
           # The metric to return when a server is probed for its load.  Options
           # are 'total', which returns the total queue length, 'estimate',
           # which returns an estimated queue length based on other probes it's
@@ -107,7 +105,12 @@ PARAMS = {'num_fes': [int, 1],             # number of frontends
           'relative_demands': [get_normalized_list, []],
           # comma separated list of relative weights with which to run tasks
           # for each user.  Currently, only integers are supported.
-          'relative_weights': [get_int_list, []]
+          'relative_weights': [get_int_list, []],
+          # Whether extra queue state should be recorded.
+          'record_queue_state': [lambda x: x == "True", False],
+          # Whether to record information about individual tasks, including
+          # expected load (based on the probe) and runtime.
+          'record_task_info': [lambda x: x == "True", False]
          }
 
 def get_param(key):
@@ -151,6 +154,15 @@ class Job(object):
         self.id_str = str(id_str)
         self.longest_task = 0
         
+        if get_param("record_task_info"):
+            # Expected load (based on the probe) and actual wait time for all
+            # tasks, indexed by the task id.
+            self.probe_results = []
+            self.wait_times = []
+            while len(self.probe_results) < self.num_tasks:
+                self.probe_results.append(-1)
+                self.wait_times.append(-1)
+        
     def get_task_length(self, task_id):
         """ Returns the time the current task takes to execute.
 
@@ -165,6 +177,21 @@ class Job(object):
                 task_length += random.expovariate(10.0 / self.task_length)
         self.longest_task = max(self.longest_task, task_length)
         return task_length
+    
+    def record_probe_result(self, task_id, load):
+        """ Records the expected load on the machine for the given task.
+        
+        This function should only be called if the "record_task_info" parameter
+        is true.
+        """
+        assert get_param("record_task_info")
+        assert task_id < self.num_tasks
+        self.probe_results[task_id] = load
+        
+    def record_launch_time(self, task_id, launch_time):
+        assert get_param("record_task_info")
+        assert task_id < self.num_tasks
+        self.wait_times[task_id] = launch_time - self.arrival_time
         
     def task_finished(self, current_time):
         """ Should be called whenever a task completes.
@@ -205,7 +232,7 @@ class Server(object):
     
     def __init__(self, id_str, stats_manager, num_users):
         # List of queues for each user, indexed by the user id.  Each queue
-        # contains (task_length, job) pairs.
+        # contains (job, task_id) pairs.
         self.queues = []
         for user in range(num_users):
             self.queues.append([])
@@ -310,9 +337,8 @@ class Server(object):
         Begins running the task, if there are no other tasks in the queue.
         Returns a TaskCompletion event, if there are no tasks running.
         """
-        task_length = job.get_task_length(task_index)
         self.queue_length += 1
-        self.queues[job.user_id].append((task_length, job))
+        self.queues[job.user_id].append((job, task_index))
         self.stats_manager.task_queued(job.user_id, current_time)
         if self.queue_length == 1:
             # There aren't any tasks currently running, so launch this one.
@@ -347,11 +373,14 @@ class Server(object):
             self.current_user = (self.current_user + 1) % self.num_users
             self.task_count = 0
         # Get the first task from the queue
-        task_length, job = self.queues[self.current_user][0]
+        job, task_id = self.queues[self.current_user][0]
         assert job.user_id == self.current_user
+        task_length = job.get_task_length(task_id)
         event = (current_time + task_length, TaskCompletion(job, self))
         self.stats_manager.task_started(self.current_user, current_time)
         self.time_started = current_time
+        if get_param("record_task_info"):
+            job.record_launch_time(task_id, current_time)
 
         return event
         
@@ -392,6 +421,8 @@ class FrontEnd(object):
         task_arrival_time = current_time + get_param("network_delay")
         for (counter, (server, length)) in enumerate(
                 self.get_best_n_queues(queue_lengths, job.num_tasks)):
+            if get_param("record_task_info"):
+                job.record_probe_result(counter, length)
             events.append((task_arrival_time,
                            TaskArrival(server, job, counter)))
             #self.logger.debug("\t%d\tAssigning job %s for user %d to %s" % 
@@ -653,6 +684,11 @@ class StatsManager(object):
         except:
             pass
         
+        if get_param("record_task_info"):
+            if get_param("load_metric") == "total":
+                self.output_wait_time_cdf()
+            else:
+                self.output_load_versus_launch_time()
         self.output_running_tasks()
         self.output_bucketed_running_tasks()
         #self.output_queue_size()
@@ -660,15 +696,124 @@ class StatsManager(object):
         #self.output_job_overhead()
         self.output_response_times()
         
-        for user_id in range(get_param("num_users")):
-            self.output_response_times(user_id)
+        if get_param("num_users") > 1:
+            for user_id in range(get_param("num_users")):
+                self.output_response_times(user_id)
          
         # This can be problematic for small total runtimes, since the number
         # of jobs with 200 tasks may be just 1 or 0.    
         if get_param("task_distribution") == "bimodal":
             self.output_per_job_size_response_time()
             
+    def output_load_versus_launch_time(self):
+        """ Outputs the predicted load and launch time for each task.
+        
+        This information is intended to help evaluate the staleness of the
+        load information from the probe.  If the information is quite stale,
+        we'd expect to see little correlation between the load and the launch
+        time of the task.
+        """
+        results_dirname = get_param("results_dir")
+        per_task_filename = os.path.join(results_dirname,
+                                         "%s_task_load_vs_wait" %
+                                         get_param("file_prefix"))
+        per_task_file = open(per_task_filename, "w")
+        per_task_file.write("load\twait_time\n")
+        
+        per_job_filename = os.path.join(results_dirname,
+                                        "%s_job_load_vs_wait" %
+                                        get_param("file_prefix"))
+        per_job_file = open(per_job_filename, "w")
+        per_job_file.write("load\twait_time\n")
+        for job in self.completed_jobs:
+            # Launch time and expected load for the last task to launch.
+            longest_task_wait = -1
+            longest_task_load = -1
+            for task_id in range(job.num_tasks):
+                load = job.probe_results[task_id]
+                wait = job.wait_times[task_id]
+                if wait > longest_task_wait:
+                    longest_task_wait = wait
+                    longest_task_load = load
+                per_task_file.write("%f\t%f\n" % (load, wait))
+                
+            per_job_file.write("%f\t%f\n" % (longest_task_load,
+                                             longest_task_wait))
+        per_job_file.close()
+        per_task_file.close()
+        
+    def output_wait_time_cdf(self):
+        """ Outputs a CDF of wait times for each probe response.
+        
+        This function should only be called if the load metric is total,
+        since otherwise, the probe responses will be non-integral (and there
+        will be potentially a large number of different responses), so the
+        output format used here won't make sense.
+        
+        Outputs two files, one with a CDF for all tasks, and one with
+        a CDF for the longest task in each job.
+        """
+        results_dirname = get_param("results_dir")
+        job_filename = os.path.join(results_dirname, "%s_job_wait_cdf" %
+                                    get_param("file_prefix"))
+        job_file = open(job_filename, "w")
+        task_filename = os.path.join(results_dirname, "%s_task_wait_cdf" %
+                                     get_param("file_prefix"))
+        task_file = open(task_filename, "w")
+        
+        wait_times_per_load = []
+        # Wait times for the last task in each job.
+        longest_wait_times_per_load = []
+        for job in self.completed_jobs:
+            longest_task_wait = -1
+            longest_task_load = -1
+            for task_id in range(job.num_tasks):
+                load = job.probe_results[task_id]
+                wait = job.wait_times[task_id]
+                if wait > longest_task_wait:
+                    longest_task_wait = wait
+                    longest_task_load = load
+                while load >= len(wait_times_per_load):
+                    wait_times_per_load.append([])
+                wait_times_per_load[load].append(wait)
+            while longest_task_load >= len(longest_wait_times_per_load):
+                longest_wait_times_per_load.append([])
+            longest_wait_times_per_load[longest_task_load].append(
+                    longest_task_wait)
+        
+        task_file.write("Percentile\t")
+        job_file.write("Percentile\t")
+        for load in range(len(wait_times_per_load)):
+            wait_times_per_load[load].sort()
+            task_file.write("%f(%d)\t" %
+                            (load, len(wait_times_per_load[load])))
+        task_file.write("\n")
+        for load in range(len(longest_wait_times_per_load)):
+            longest_wait_times_per_load[load].sort()
+            job_file.write("%f(%d)\t" %
+                           (load, len(longest_wait_times_per_load[load])))
+        job_file.write("\n")
+
+        percentile_granularity = 200
+        for i in range(percentile_granularity):
+            percentile = float(i) / percentile_granularity
+            job_file.write("%f" % percentile)
+            task_file.write("%f" % percentile)
+            for wait_times in longest_wait_times_per_load:
+                job_file.write("\t%f" %
+                               self.percentile(wait_times, percentile))
+            job_file.write("\n")
+            for wait_times in wait_times_per_load:
+                task_file.write("\t%f" %
+                                self.percentile(wait_times, percentile))
+            task_file.write("\n")
+        job_file.close()
+            
     def output_bucketed_running_tasks(self):
+        """ Writes the number of running tasks for each user.
+        
+        The number of running tasks are bucketed over some interval, to give
+        a sense of fairness over time. """
         bucketed_running_tasks_per_user = []
         bucket_interval = 100
         
@@ -681,7 +826,7 @@ class StatsManager(object):
 
         for user_id in range(get_param("num_users")):
             bucketed_running_tasks = []
-            # Total number of CPU millseconds used during this bucket.
+            # Total number of CPU milliseconds used during this bucket.
             cpu_millis = 0
             current_running_tasks = 0
             # Last time we got a measurement for the number of running tasks.
@@ -875,7 +1020,7 @@ class StatsManager(object):
                  get_param("num_servers"), avg_empty_queues))
         f.close()
         
-        # Write CDF of response times
+        # Write CDF of response times.
         #filename = os.path.join(results_dirname, "%s_response_time_cdf" %
         #                       get_param("file_prefix"))
         #f = open(filename, "w")


### PR DESCRIPTION
We were witnessing two pieces of unexplainable behavior; this
commit adds code to explain both pieces of behavior.  The first
piece of surprising behavior was that we were seeing surprisingly
long response times for random placement, even at low utilizations.
The second surprising thing was that the the response times for all
jobs in a given run of the simulation showed step-like behavior,
where most jobs finished at 100-millisecond intervals (for jobs
with 100-millisecond tasks).

To understand this behavior, this commit adds code to record the
wait time for tasks as a function of the result of the probe;
the graphs produced by this code clearly explain both behaviors.
