### PR TITLE
Creating a re-usable thrift client pool.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,17 @@
 		<version>0.8.0</version>
 	</dependency>
 	<dependency>
+    <groupId>org.mockito</groupId>
+    <artifactId>mockito-core</artifactId>  
+    <version>1.9.0</version> 
+    <scope>test</scope>
+  </dependency>
+  <dependency>
+	  <groupId>commons-pool</groupId>
+		<artifactId>commons-pool</artifactId>
+	  <version>1.6</version>
+  </dependency>
+	<dependency>
     <groupId>edu.berkeley</groupId>
     <artifactId>mesos</artifactId>
     <version>1.0</version>

--- a/src/main/java/edu/berkeley/sparrow/daemon/scheduler/MinCpuAssignmentPolicy.java
+++ b/src/main/java/edu/berkeley/sparrow/daemon/scheduler/MinCpuAssignmentPolicy.java
@@ -9,13 +9,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import org.apache.thrift.transport.TNonblockingTransport;
-import org.apache.thrift.transport.TTransport;
-
-import com.google.common.base.Optional;
-
 import edu.berkeley.sparrow.daemon.scheduler.TaskPlacer.TaskPlacementResponse;
-import edu.berkeley.sparrow.thrift.InternalService;
 import edu.berkeley.sparrow.thrift.TResourceVector;
 import edu.berkeley.sparrow.thrift.TTaskSpec;
 
@@ -50,15 +44,12 @@ public class MinCpuAssignmentPolicy implements AssignmentPolicy {
     
     ArrayList<TaskPlacementResponse> out = new ArrayList<TaskPlacementResponse>();
     
-    Optional<InternalService.AsyncClient> client = Optional.absent();
-    Optional<TNonblockingTransport> transport = Optional.absent();
-    
     int i = 0;
     for (TTaskSpec task : tasks) {
       Entry<InetSocketAddress, TResourceVector> entry = results.get(i++ % results.size());
       
       TaskPlacementResponse place = new TaskPlacementResponse(
-          task, entry.getKey(), client, transport);
+          task, entry.getKey());
       out.add(place);
     }
     return out;

--- a/src/main/java/edu/berkeley/sparrow/daemon/scheduler/ProbingTaskPlacer.java
+++ b/src/main/java/edu/berkeley/sparrow/daemon/scheduler/ProbingTaskPlacer.java
@@ -37,7 +37,7 @@ public class ProbingTaskPlacer implements TaskPlacer {
   /**
    * This acts as a callback for the asynchronous Thrift interface.
    */
-  public class ProbeCallback implements AsyncMethodCallback<getLoad_call> {
+  private class ProbeCallback implements AsyncMethodCallback<getLoad_call> {
     InetSocketAddress socket;
     /** This should not be modified after the {@code latch} count is zero! */
     Map<InetSocketAddress, TResourceVector> loads;

--- a/src/main/java/edu/berkeley/sparrow/daemon/scheduler/ProbingTaskPlacer.java
+++ b/src/main/java/edu/berkeley/sparrow/daemon/scheduler/ProbingTaskPlacer.java
@@ -37,7 +37,7 @@ public class ProbingTaskPlacer implements TaskPlacer {
   /**
    * This acts as a callback for the asynchronous Thrift interface.
    */
-  private class ProbeCallback implements AsyncMethodCallback<getLoad_call> {
+  public class ProbeCallback implements AsyncMethodCallback<getLoad_call> {
     InetSocketAddress socket;
     /** This should not be modified after the {@code latch} count is zero! */
     Map<InetSocketAddress, TResourceVector> loads;
@@ -48,7 +48,7 @@ public class ProbingTaskPlacer implements TaskPlacer {
     private String requestId;
     private AsyncClient client;
     
-    private ProbeCallback(
+    ProbeCallback(
         InetSocketAddress socket, Map<InetSocketAddress, TResourceVector> loads, 
         CountDownLatch latch, String appId, String requestId, AsyncClient client) {
       this.socket = socket;

--- a/src/main/java/edu/berkeley/sparrow/daemon/scheduler/RandomTaskPlacer.java
+++ b/src/main/java/edu/berkeley/sparrow/daemon/scheduler/RandomTaskPlacer.java
@@ -8,12 +8,13 @@ import java.util.Collections;
 import java.util.HashSet;
 
 import org.apache.commons.configuration.Configuration;
-import org.apache.thrift.async.TAsyncClientManager;
 import org.apache.thrift.transport.TNonblockingTransport;
 
 import com.google.common.base.Optional;
 
+import edu.berkeley.sparrow.daemon.util.ThriftClientPool;
 import edu.berkeley.sparrow.thrift.InternalService;
+import edu.berkeley.sparrow.thrift.InternalService.AsyncClient;
 import edu.berkeley.sparrow.thrift.TTaskSpec;
 
 /***
@@ -25,8 +26,8 @@ public class RandomTaskPlacer implements TaskPlacer {
   
   @Override
   public Collection<TaskPlacementResponse> placeTasks(String appId,
-      String requestId, Collection<InetSocketAddress> nodes, Collection<TTaskSpec> tasks, 
-      TAsyncClientManager clientManager) throws IOException {
+      String requestId, Collection<InetSocketAddress> nodes, Collection<TTaskSpec> tasks)
+          throws IOException {
     Collection<TaskPlacementResponse> out = new HashSet<TaskPlacementResponse>();
     
     ArrayList<InetSocketAddress> orderedNodes = new ArrayList<InetSocketAddress>(nodes);
@@ -47,6 +48,7 @@ public class RandomTaskPlacer implements TaskPlacer {
   }
 
   @Override
-  public void initialize(Configuration conf) {
+  public void initialize(Configuration conf, ThriftClientPool<AsyncClient> clientPool) {
   }
+
 }

--- a/src/main/java/edu/berkeley/sparrow/daemon/scheduler/RandomTaskPlacer.java
+++ b/src/main/java/edu/berkeley/sparrow/daemon/scheduler/RandomTaskPlacer.java
@@ -8,12 +8,8 @@ import java.util.Collections;
 import java.util.HashSet;
 
 import org.apache.commons.configuration.Configuration;
-import org.apache.thrift.transport.TNonblockingTransport;
-
-import com.google.common.base.Optional;
 
 import edu.berkeley.sparrow.daemon.util.ThriftClientPool;
-import edu.berkeley.sparrow.thrift.InternalService;
 import edu.berkeley.sparrow.thrift.InternalService.AsyncClient;
 import edu.berkeley.sparrow.thrift.TTaskSpec;
 
@@ -33,15 +29,10 @@ public class RandomTaskPlacer implements TaskPlacer {
     ArrayList<InetSocketAddress> orderedNodes = new ArrayList<InetSocketAddress>(nodes);
     Collections.shuffle(orderedNodes);
     
-    // Empty client/transport used for all responses
-    Optional<InternalService.AsyncClient> client = Optional.absent();
-    Optional<TNonblockingTransport> transport = Optional.absent();
-   
     int i = 0;
     for (TTaskSpec task : tasks) {
       InetSocketAddress addr = orderedNodes.get(i++ % nodes.size());
-      TaskPlacementResponse response = new TaskPlacementResponse(task,
-          addr, client, transport);
+      TaskPlacementResponse response = new TaskPlacementResponse(task, addr);
       out.add(response);
     }
     return out;

--- a/src/main/java/edu/berkeley/sparrow/daemon/scheduler/Scheduler.java
+++ b/src/main/java/edu/berkeley/sparrow/daemon/scheduler/Scheduler.java
@@ -67,6 +67,7 @@ public class Scheduler {
     private InternalService.AsyncClient client;
     private InetSocketAddress socket;
 
+    // Note that the {@code client} must come from the Scheduler's {@code clientPool}.
     public TaskLaunchCallback(CountDownLatch latch, InternalService.AsyncClient client,
         InetSocketAddress socket) {
       this.latch = latch;
@@ -101,7 +102,7 @@ public class Scheduler {
   public void initialize(Configuration conf, InetSocketAddress socket) throws IOException {
     address = socket;
     clientPool = new ThriftClientPool<InternalService.AsyncClient>(
-        new ThriftClientPool.InernalServiceMakerFactory());
+        new ThriftClientPool.InternalServiceMakerFactory());
     String mode = conf.getString(SparrowConf.DEPLYOMENT_MODE, "unspecified");
     if (mode.equals("standalone")) {
       state = new StandaloneSchedulerState();

--- a/src/main/java/edu/berkeley/sparrow/daemon/scheduler/Scheduler.java
+++ b/src/main/java/edu/berkeley/sparrow/daemon/scheduler/Scheduler.java
@@ -15,12 +15,6 @@ import org.apache.commons.configuration.Configuration;
 import org.apache.log4j.Logger;
 import org.apache.thrift.TException;
 import org.apache.thrift.async.AsyncMethodCallback;
-import org.apache.thrift.async.TAsyncClientManager;
-import org.apache.thrift.protocol.TBinaryProtocol;
-import org.apache.thrift.protocol.TProtocolFactory;
-import org.apache.thrift.transport.TNonblockingSocket;
-import org.apache.thrift.transport.TNonblockingTransport;
-import org.apache.thrift.transport.TTransport;
 import org.mortbay.log.Log;
 
 import com.google.common.base.Optional;
@@ -30,6 +24,7 @@ import edu.berkeley.sparrow.daemon.scheduler.TaskPlacer.TaskPlacementResponse;
 import edu.berkeley.sparrow.daemon.util.Logging;
 import edu.berkeley.sparrow.daemon.util.Serialization;
 import edu.berkeley.sparrow.daemon.util.TClients;
+import edu.berkeley.sparrow.daemon.util.ThriftClientPool;
 import edu.berkeley.sparrow.thrift.FrontendService.Client;
 import edu.berkeley.sparrow.thrift.InternalService;
 import edu.berkeley.sparrow.thrift.InternalService.AsyncClient.launchTask_call;
@@ -52,8 +47,8 @@ public class Scheduler {
   HashMap<String, InetSocketAddress> frontendSockets = 
       new HashMap<String, InetSocketAddress>();
   
-  /** Pointer to shared selector thread. */
-  TAsyncClientManager clientManager;
+  /** Thrift client pool */
+  ThriftClientPool<InternalService.AsyncClient> clientPool;
   
   /** Information about cluster workload due to other schedulers. */
   SchedulerState state;
@@ -69,32 +64,44 @@ public class Scheduler {
    */
   private class TaskLaunchCallback implements AsyncMethodCallback<launchTask_call> {
     private CountDownLatch latch;
-    private TTransport transport;
+    private InternalService.AsyncClient client;
+    private InetSocketAddress socket;
 
-    public TaskLaunchCallback(CountDownLatch latch, TTransport transport) {
+    public TaskLaunchCallback(CountDownLatch latch, InternalService.AsyncClient client,
+        InetSocketAddress socket) {
       this.latch = latch;
-      this.transport = transport;
+      this.client = client;
+      this.socket = socket;
     }
     
     @Override
     public void onComplete(launchTask_call response) {
+      try {
+        clientPool.returnClient(socket, client);
+      } catch (Exception e) {
+        LOG.error(e);
+      }
       latch.countDown();
-      transport.close();
     }
 
     @Override
     public void onError(Exception exception) {
       LOG.error("Error launching task: " + exception);
+      try {
+        clientPool.returnClient(socket, client);
+      } catch (Exception e) {
+        LOG.error(e);
+      }
       // TODO We need to have a story here, regarding the failure model when the
       //      probe doesn't succeed.
-      transport.close();
       latch.countDown();
     }
   }
 
   public void initialize(Configuration conf, InetSocketAddress socket) throws IOException {
     address = socket;
-    clientManager = new TAsyncClientManager();
+    clientPool = new ThriftClientPool<InternalService.AsyncClient>(
+        new ThriftClientPool.InernalServiceMakerFactory());
     String mode = conf.getString(SparrowConf.DEPLYOMENT_MODE, "unspecified");
     if (mode.equals("standalone")) {
       state = new StandaloneSchedulerState();
@@ -110,7 +117,7 @@ public class Scheduler {
     }
     
     state.initialize(conf);
-    placer.initialize(conf);
+    placer.initialize(conf, clientPool);
   }
   
   public boolean registerFrontend(String appId, String addr) {
@@ -141,7 +148,7 @@ public class Scheduler {
     try {
       placement = getJobPlacementResp(req, requestId);
     } catch (IOException e) {
-      e.printStackTrace();
+      LOG.error(e);
       return false;
     }
     long probeFinish = System.currentTimeMillis();
@@ -151,22 +158,12 @@ public class Scheduler {
     for (TaskPlacementResponse response : placement) {
       LOG.debug("Attempting to launch task on " + response.getNodeAddr());
 
-      InternalService.AsyncClient client = null;
-      TNonblockingTransport transport = null;
-      if (!response.getClient().isPresent()) {
-        try {
-          transport = new TNonblockingSocket(
-              response.getNodeAddr().getHostName(), response.getNodeAddr().getPort());
-        } catch (IOException e) {
-          LOG.error(e);
-          return false;
-        }
-        TProtocolFactory factory = new TBinaryProtocol.Factory();
-        client = new InternalService.AsyncClient(
-            factory, clientManager, transport);
-      } else {
-        client = response.getClient().get();
-        transport = response.getTransport().get();
+      InternalService.AsyncClient client;
+      try {
+        client = clientPool.borrowClient(response.getNodeAddr());
+      } catch (Exception e) {
+        LOG.error(e);
+        return false;
       }
       String taskId = response.getTaskSpec().taskID;
 
@@ -174,7 +171,7 @@ public class Scheduler {
       client.launchTask(req.getApp(), response.getTaskSpec().message, requestId,
           taskId, req.getUser(), response.getTaskSpec().getEstimatedResources(),
           address.getHostName() + ":" + address.getPort(),
-          new TaskLaunchCallback(latch, transport));
+          new TaskLaunchCallback(latch, client, response.getNodeAddr()));
     }
     try {
       LOG.debug("Waiting for " + placement.size() + " tasks to finish launching");
@@ -220,7 +217,7 @@ public class Scheduler {
     for (InetSocketAddress backend : backends) {
       backendList.add(backend);
     }
-    return placer.placeTasks(app, requestId, backendList, tasks, clientManager);
+    return placer.placeTasks(app, requestId, backendList, tasks);
   }
   
   /**

--- a/src/main/java/edu/berkeley/sparrow/daemon/scheduler/TaskPlacer.java
+++ b/src/main/java/edu/berkeley/sparrow/daemon/scheduler/TaskPlacer.java
@@ -5,12 +5,14 @@ import java.net.InetSocketAddress;
 import java.util.Collection;
 
 import org.apache.commons.configuration.Configuration;
-import org.apache.thrift.async.TAsyncClientManager;
 import org.apache.thrift.transport.TNonblockingTransport;
 
 import com.google.common.base.Optional;
 
+import edu.berkeley.sparrow.daemon.nodemonitor.NodeMonitor;
+import edu.berkeley.sparrow.daemon.util.ThriftClientPool;
 import edu.berkeley.sparrow.thrift.InternalService;
+import edu.berkeley.sparrow.thrift.InternalService.AsyncClient;
 import edu.berkeley.sparrow.thrift.TTaskSpec;
 
 /***
@@ -21,34 +23,19 @@ public interface TaskPlacer {
   public class TaskPlacementResponse {
     private TTaskSpec taskSpec; // Original request specification 
     private InetSocketAddress nodeAddr;
-    private Optional<InternalService.AsyncClient> client; // Pointer to thrift client, if 
-                                                        // this TaskPlacer spoke to Thrift
-    private Optional<TNonblockingTransport> transport;
     
     public TaskPlacementResponse(TTaskSpec taskSpec, InetSocketAddress nodeAddr, 
         Optional<InternalService.AsyncClient> client, Optional<TNonblockingTransport> transport) {
       this.taskSpec = taskSpec;
-      this.client = client;
       this.nodeAddr = nodeAddr;
-      this.transport = transport;
     }
     
     public TTaskSpec getTaskSpec() { return this.taskSpec; }
     public InetSocketAddress getNodeAddr() { return this.nodeAddr; }
-    public Optional<InternalService.AsyncClient> getClient() { return this.client; }
-    public Optional<TNonblockingTransport> getTransport() { return this.transport; }
-    
-    public void setTransport(TNonblockingTransport transport) {
-      this.transport = Optional.of(transport);
-    }
-    
-    public void setClient(InternalService.AsyncClient client) {
-      this.client = Optional.of(client);
-    }
   }
   
   /** Initialize this TaskPlacer. */
-  void initialize(Configuration conf);
+  void initialize(Configuration conf, ThriftClientPool<AsyncClient> clientPool);
   
   /**
    * Given a list of {@link NodeMonitor} network addresses and a list of
@@ -56,10 +43,9 @@ public interface TaskPlacer {
    * @throws IOException 
    */
   Collection<TaskPlacementResponse> placeTasks(String appId,
-      String requestId, Collection<InetSocketAddress> nodes, Collection<TTaskSpec> tasks,
-      TAsyncClientManager clientManager) throws IOException;
+      String requestId, Collection<InetSocketAddress> nodes, Collection<TTaskSpec> tasks)
+          throws IOException;
   // TODO: For performance reasons it might make sense to just have these arguments as 
   //       List rather than Collection since they need to be returned as a list eventually.
-
 
 }

--- a/src/main/java/edu/berkeley/sparrow/daemon/scheduler/TaskPlacer.java
+++ b/src/main/java/edu/berkeley/sparrow/daemon/scheduler/TaskPlacer.java
@@ -5,13 +5,9 @@ import java.net.InetSocketAddress;
 import java.util.Collection;
 
 import org.apache.commons.configuration.Configuration;
-import org.apache.thrift.transport.TNonblockingTransport;
-
-import com.google.common.base.Optional;
 
 import edu.berkeley.sparrow.daemon.nodemonitor.NodeMonitor;
 import edu.berkeley.sparrow.daemon.util.ThriftClientPool;
-import edu.berkeley.sparrow.thrift.InternalService;
 import edu.berkeley.sparrow.thrift.InternalService.AsyncClient;
 import edu.berkeley.sparrow.thrift.TTaskSpec;
 
@@ -24,8 +20,7 @@ public interface TaskPlacer {
     private TTaskSpec taskSpec; // Original request specification 
     private InetSocketAddress nodeAddr;
     
-    public TaskPlacementResponse(TTaskSpec taskSpec, InetSocketAddress nodeAddr, 
-        Optional<InternalService.AsyncClient> client, Optional<TNonblockingTransport> transport) {
+    public TaskPlacementResponse(TTaskSpec taskSpec, InetSocketAddress nodeAddr) {
       this.taskSpec = taskSpec;
       this.nodeAddr = nodeAddr;
     }

--- a/src/main/java/edu/berkeley/sparrow/daemon/util/ThriftClientPool.java
+++ b/src/main/java/edu/berkeley/sparrow/daemon/util/ThriftClientPool.java
@@ -1,0 +1,143 @@
+package edu.berkeley.sparrow.daemon.util;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.HashMap;
+
+import org.apache.commons.pool.KeyedPoolableObjectFactory;
+import org.apache.commons.pool.impl.GenericKeyedObjectPool;
+import org.apache.commons.pool.impl.GenericKeyedObjectPool.Config;
+import org.apache.log4j.Logger;
+import org.apache.thrift.async.TAsyncClient;
+import org.apache.thrift.async.TAsyncClientManager;
+import org.apache.thrift.protocol.TBinaryProtocol;
+import org.apache.thrift.protocol.TProtocolFactory;
+import org.apache.thrift.transport.TNonblockingSocket;
+import org.apache.thrift.transport.TNonblockingTransport;
+
+import edu.berkeley.sparrow.thrift.InternalService;
+
+/** A pool of nonblocking thrift async connections. */
+public class ThriftClientPool<T extends TAsyncClient> {
+  // Default configurations for underlying pool
+  /** See {@link GenericKeyedObjectPool.Config} */
+  public static int MIN_IDLE_CLIENTS_PER_ADDR = 0;
+  /** See {@link GenericKeyedObjectPool.Config} */
+  public static int EVICTABLE_IDLE_TIME_MS = 1000;
+  /** See {@link GenericKeyedObjectPool.Config} */
+  public static int TIME_BETWEEN_EVICTION_RUNS_MILLIS = 1000;
+  
+  private static final Logger LOG = Logger.getLogger(ThriftClientPool.class);
+  
+  /** Get the configuration parameters used on the underlying client pool. */
+  protected static Config getPoolConfig() {
+    Config conf = new Config();
+    conf.minIdle = MIN_IDLE_CLIENTS_PER_ADDR;
+    conf.minEvictableIdleTimeMillis = EVICTABLE_IDLE_TIME_MS;
+    conf.timeBetweenEvictionRunsMillis = TIME_BETWEEN_EVICTION_RUNS_MILLIS;
+    return conf;
+  }
+  
+  /** Clients need to provide an instance of this factory which is capable of creating
+   * the a thrift client of type <T>. */
+  public interface MakerFactory<T> {
+    public T create(TNonblockingTransport tr, TAsyncClientManager mgr, 
+        TProtocolFactory factory);
+  }
+  
+  // MakerFactory implementations for Sparrow interfaces...
+  public static class InernalServiceMakerFactory 
+    implements MakerFactory<InternalService.AsyncClient> {
+    @Override
+    public InternalService.AsyncClient create(TNonblockingTransport tr, 
+        TAsyncClientManager mgr, TProtocolFactory factory) {
+      return new InternalService.AsyncClient(factory, mgr, tr);
+    }
+  }
+  
+  private class PoolFactory implements KeyedPoolableObjectFactory<InetSocketAddress, T> {
+    // Thrift clients to not expose their underlying transports, so we track them
+    // separately here to let us call close() on the transport associated with a 
+    // particular client.
+    private HashMap<T, TNonblockingTransport> transports =
+        new HashMap<T, TNonblockingTransport>(); 
+    private MakerFactory<T> maker;
+    
+    public PoolFactory(MakerFactory<T> maker) {
+      this.maker = maker;
+    }
+    
+    @Override
+    public void destroyObject(InetSocketAddress socket, T client) throws Exception {
+      transports.get(client).close();
+      transports.remove(client);
+    }
+
+    @Override
+    public T makeObject(InetSocketAddress socket) throws Exception {
+      TNonblockingTransport nbTr = new TNonblockingSocket(
+          socket.getHostName(), socket.getPort());
+      TProtocolFactory factory = new TBinaryProtocol.Factory();
+      T client = maker.create(nbTr, clientManager, factory);
+      transports.put(client, nbTr);
+      return client;
+    }
+    
+    @Override
+    public boolean validateObject(InetSocketAddress socket, T client) {
+      return transports.get(client).isOpen();
+    }
+
+    @Override
+    public void activateObject(InetSocketAddress socket, T client) throws Exception {
+      // Nothing to do here
+    }
+    @Override
+    public void passivateObject(InetSocketAddress socket, T client)
+        throws Exception {
+      // Nothing to do here
+    }
+  }  
+   
+  /** Pointer to shared selector thread. */
+  TAsyncClientManager clientManager;
+
+  /** Underlying object pool. */
+  private GenericKeyedObjectPool<InetSocketAddress, T> pool;
+  
+  public ThriftClientPool(MakerFactory<T> maker) {
+    pool = new GenericKeyedObjectPool<InetSocketAddress, T>(new PoolFactory(maker));
+    pool.setConfig(getPoolConfig());
+    try {
+      clientManager = new TAsyncClientManager();
+    } catch (IOException e) {
+      LOG.fatal(e);
+    }
+  }
+  
+  /** Constructor (for unit tests) which overrides default configuration. */
+  protected ThriftClientPool(MakerFactory<T> maker, Config conf) {
+    this(maker);
+    pool.setConfig(conf);
+  }
+    
+  /** Borrows a client from the pool. */
+  public T borrowClient(InetSocketAddress socket) 
+      throws Exception {
+    return pool.borrowObject(socket);
+  }
+  
+  /** Returns a client to the pool. */
+  public void returnClient(InetSocketAddress socket, T client) 
+      throws Exception {
+    pool.returnObject(socket, client);
+  }
+  
+  protected int getNumActive(InetSocketAddress socket) {
+    return pool.getNumActive(socket);
+  }
+  
+  protected int getNumIdle(InetSocketAddress socket) {
+    return pool.getNumIdle(socket);
+  }
+}

--- a/src/main/java/edu/berkeley/sparrow/daemon/util/ThriftClientPool.java
+++ b/src/main/java/edu/berkeley/sparrow/daemon/util/ThriftClientPool.java
@@ -46,7 +46,7 @@ public class ThriftClientPool<T extends TAsyncClient> {
   }
   
   // MakerFactory implementations for Sparrow interfaces...
-  public static class InernalServiceMakerFactory 
+  public static class InternalServiceMakerFactory 
     implements MakerFactory<InternalService.AsyncClient> {
     @Override
     public InternalService.AsyncClient create(TNonblockingTransport tr, 
@@ -92,6 +92,7 @@ public class ThriftClientPool<T extends TAsyncClient> {
     public void activateObject(InetSocketAddress socket, T client) throws Exception {
       // Nothing to do here
     }
+    
     @Override
     public void passivateObject(InetSocketAddress socket, T client)
         throws Exception {

--- a/src/test/java/edu/berkeley/sparrow/daemon/util/TestThriftClientPool.java
+++ b/src/test/java/edu/berkeley/sparrow/daemon/util/TestThriftClientPool.java
@@ -1,0 +1,89 @@
+package edu.berkeley.sparrow.daemon.util;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import java.net.InetSocketAddress;
+
+import org.apache.commons.pool.impl.GenericKeyedObjectPool.Config;
+import org.apache.thrift.async.TAsyncClient;
+import org.apache.thrift.async.TAsyncClientManager;
+import org.apache.thrift.protocol.TProtocolFactory;
+import org.apache.thrift.transport.TNonblockingTransport;
+import org.junit.Test;
+
+import edu.berkeley.sparrow.daemon.util.ThriftClientPool.MakerFactory;
+
+public class TestThriftClientPool {
+
+  private class MockedMakerFactory implements MakerFactory<TAsyncClient> {
+    @Override
+    public TAsyncClient create(TNonblockingTransport tr,
+        TAsyncClientManager mgr, TProtocolFactory factory) {
+      return mock(TAsyncClient.class);
+    }
+  }
+  
+  @Test
+  public void ensureConnectionReUsed() throws Exception {
+    // Test a very common scenario where we make two thrift function calls to the same
+    // node in rapid succession. This test ensures that a single client is created and 
+    // for both calls. 
+    
+    InetSocketAddress sock = new InetSocketAddress(12345);
+    ThriftClientPool<TAsyncClient> pool = new ThriftClientPool<TAsyncClient>(
+        new MockedMakerFactory());
+    assertEquals(0, pool.getNumIdle(sock));
+    assertEquals(0, pool.getNumActive(sock));
+
+    TAsyncClient client1 = pool.borrowClient(sock);
+    
+    assertEquals(0, pool.getNumIdle(sock));
+    assertEquals(1, pool.getNumActive(sock));
+    
+    pool.returnClient(sock, client1);
+    
+    assertEquals(1, pool.getNumIdle(sock));
+    assertEquals(0, pool.getNumActive(sock));
+    
+    TAsyncClient client2 = pool.borrowClient(sock);
+
+    assertEquals(0, pool.getNumIdle(sock));
+    assertEquals(1, pool.getNumActive(sock));
+    
+    assertEquals(client1, client2);
+  }
+  
+  @Test
+  public void testPoolExpiration() throws Exception {
+    // Makes sure that a thrift client gets evicted (and therefore closed) if it is not 
+    // used for a certain amount of time.
+    Config conf = ThriftClientPool.getPoolConfig();
+    
+    // We decrease the defaults here so the test runs in reasonable time
+    conf.minEvictableIdleTimeMillis = 10;
+    conf.timeBetweenEvictionRunsMillis = 50;
+    
+    InetSocketAddress sock = new InetSocketAddress(12345);    
+    
+    ThriftClientPool<TAsyncClient> pool = new ThriftClientPool<TAsyncClient>(
+        new MockedMakerFactory(), conf);
+    
+    assertEquals(0, pool.getNumIdle(sock));
+    assertEquals(0, pool.getNumActive(sock));
+    
+    TAsyncClient client = pool.borrowClient(sock);
+    
+    assertEquals(0, pool.getNumIdle(sock));
+    assertEquals(1, pool.getNumActive(sock));
+    
+    pool.returnClient(sock, client);
+    
+    assertEquals(1, pool.getNumIdle(sock));
+    assertEquals(0, pool.getNumActive(sock));
+    
+    Thread.sleep(100);
+    
+    assertEquals(0, pool.getNumIdle(sock));
+    assertEquals(0, pool.getNumActive(sock));
+  }
+}

--- a/src/test/java/edu/berkeley/sparrow/daemon/util/TestThriftClientPool.java
+++ b/src/test/java/edu/berkeley/sparrow/daemon/util/TestThriftClientPool.java
@@ -23,12 +23,11 @@ public class TestThriftClientPool {
     }
   }
   
+  /** Test a very common scenario where we make two thrift function calls to the same
+      node in rapid succession. This test ensures that a single client is created and 
+      used for both calls. */
   @Test
   public void ensureConnectionReUsed() throws Exception {
-    // Test a very common scenario where we make two thrift function calls to the same
-    // node in rapid succession. This test ensures that a single client is created and 
-    // for both calls. 
-    
     InetSocketAddress sock = new InetSocketAddress(12345);
     ThriftClientPool<TAsyncClient> pool = new ThriftClientPool<TAsyncClient>(
         new MockedMakerFactory());
@@ -81,7 +80,7 @@ public class TestThriftClientPool {
     assertEquals(1, pool.getNumIdle(sock));
     assertEquals(0, pool.getNumActive(sock));
     
-    Thread.sleep(100);
+    Thread.sleep(conf.timeBetweenEvictionRunsMillis * 2);
     
     assertEquals(0, pool.getNumIdle(sock));
     assertEquals(0, pool.getNumActive(sock));


### PR DESCRIPTION
This patch introduces a generic client pool for any async thrift client. It also
re-writes some exsiting code to use the client pool.

The pool itself is written/tested in ThriftClientPool and TestThriftClientPool
. It relies on the Apache Commons pooling service.

The TaskPlacer interface is modified to use a shared client pool rather than
explicitly passing handles to particular sockets/clients.

The ProbingTaskPlacer and Scheduler classes are modified to use the client
pool rather than directly dealing with creating/closing Thrift clients.
